### PR TITLE
Remove Airflow Constraints File

### DIFF
--- a/airflow_constraints.txt
+++ b/airflow_constraints.txt
@@ -1,1 +1,0 @@
-https://raw.githubusercontent.com/apache/airflow/constraints-2.3.2/constraints-3.10.txt


### PR DESCRIPTION
## What Does This Do?

Exactly what it says. We no longer need the constraints file after closing out [Find Poetry Workaround For Installing Apache Airflow #1](https://github.com/mseminara0415/Portfolio_Website/issues/1).

This PR is obviously extremely simple and probably doesn't need a PR, but getting used to using git CLI to create and push local branches to the remote repo.